### PR TITLE
improvement for datadog wrapper

### DIFF
--- a/contrib/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/opentracer/opentracer.go
+++ b/contrib/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/opentracer/opentracer.go
@@ -3,8 +3,27 @@ package opentracer
 import (
 	"github.com/opentracing/opentracing-go"
 	dd "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/opentracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	ddtracer "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
+
+type component struct {
+	component string
+}
+
+func (c component) Apply(opts *opentracing.StartSpanOptions) {
+	if opts == nil {
+		return
+	}
+	if c.component != "" {
+		opts.Tags["component"] = c.component
+	}
+}
+
+// ComponentOption can give component for span
+func ComponentOption(c string) opentracing.StartSpanOption {
+	return component{c}
+}
 
 type opentracer struct {
 	tracer      opentracing.Tracer
@@ -14,24 +33,30 @@ type opentracer struct {
 // New creates, DataDog tracer instance and wraps it so
 // that standard operation name and component definitions
 // can be used
-func New(opts ...ddtracer.StartOption) opentracing.Tracer {
-	// FIXME: set service name
-	return &opentracer{tracer: dd.New(opts...)}
+func New(serviceName string, opts ...ddtracer.StartOption) opentracing.Tracer {
+	opts = append(opts, tracer.WithServiceName(serviceName))
+	return &opentracer{
+		serviceName: serviceName,
+		tracer:      dd.New(opts...),
+	}
 }
 
 // StartSpan wraps DataDog opentracing tracer StartSpan to change
 // operation name and component name to be correct in Datadog perspective
 func (o *opentracer) StartSpan(operationName string, opts ...opentracing.StartSpanOption) opentracing.Span {
 	ddopts := []opentracing.StartSpanOption{}
-	// Component name is now hardcoded to "http.request". This should be
-	// changed to be dynamic later
-	component := "http.request"
+	componentName := "http.request"
+	for _, opt := range opts {
+		if c, ok := opt.(component); ok {
+			componentName = c.component
+		}
+	}
 
 	ddopts = append(ddopts, opts...)
 	ddopts = append(ddopts, dd.ResourceName(operationName))
 	ddopts = append(ddopts, dd.ServiceName(o.serviceName))
 
-	return o.tracer.StartSpan(component, ddopts...)
+	return o.tracer.StartSpan(componentName, ddopts...)
 }
 
 // Inject directly calls DataDog opentracer tracer Inject function

--- a/contrib/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/opentracer/opentracer_test.go
+++ b/contrib/gopkg.in/DataDog/dd-trace-go.v1/ddtrace/opentracer/opentracer_test.go
@@ -1,0 +1,76 @@
+package opentracer
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/opentracing/opentracing-go"
+)
+
+func TestComponentApply(t *testing.T) {
+	tests := []struct {
+		name      string
+		component string
+		opts      *opentracing.StartSpanOptions
+	}{
+		{"nil opts and empty name", "", nil},
+		{"nil opts and name", "test", nil},
+		{"opts and empty name", "", &opentracing.StartSpanOptions{Tags: map[string]interface{}{}}},
+		{"opts and name", "test", &opentracing.StartSpanOptions{Tags: map[string]interface{}{}}},
+		{"component in opts and empty name", "", &opentracing.StartSpanOptions{Tags: map[string]interface{}{"component": "c"}}},
+		{"component in opts and name", "test", &opentracing.StartSpanOptions{Tags: map[string]interface{}{"component": "c"}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := component{
+				component: tt.component,
+			}
+			c.Apply(tt.opts)
+			if tt.opts != nil && tt.component != "" {
+				if v, exists := tt.opts.Tags["component"]; exists {
+					if c, ok := v.(string); ok {
+						if c != tt.component {
+							t.Errorf("incorrect component name, expected: '%s', got: '%s'", c, tt.component)
+						}
+					} else {
+						t.Errorf("Incorrect component type, should be string")
+					}
+				} else {
+					t.Errorf("Component name does not exists even it should be: '%s'", tt.component)
+				}
+
+			}
+			if tt.opts != nil && tt.component == "" {
+				if v, exists := tt.opts.Tags["component"]; exists {
+					if c, ok := v.(string); ok {
+						if c == tt.component {
+							t.Errorf("incorrect component name, expected not to be '%s'", tt.component)
+						}
+					} else {
+						t.Errorf("Incorrect component type, should be string")
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestComponentOption(t *testing.T) {
+	tests := []struct {
+		name string
+		c    string
+		want component
+	}{
+		{"empty name", "", component{component: ""}},
+		{"name", "test", component{component: "test"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ComponentOption(tt.c).(component)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ComponentOption() = %v, want %v", got, tt.want)
+			}
+
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/foodiefm/opentracing
 
-go 1.12
+go 1.13
 
 require (
 	github.com/gin-gonic/gin v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/gin-contrib/sse v0.0.0-20190301062529-5545eab6dad3 h1:t8FVkw33L+wilf2QiWkw0UV77qRpcH/JHPKGpKa2E8g=


### PR DESCRIPTION
service name and configurable component name handling added to datadog tracer wrapper

Own type created to component name, so that its type can be easily checked
inside tracer to allow special handling.